### PR TITLE
PP-11314 include registry during node setup

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -24,6 +24,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm ci
       - name: Build project


### PR DESCRIPTION
### WHAT

In order to correctly authenticate with the NPM access token, `actions/setup-node` needs to be provided a `registry-url` value.