### PR TITLE
PP-12687: Add dependency review workflow

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -1,7 +1,7 @@
 name: Run tests
 
 on:
-  pull_request:
+  workflow_dispatch:
   workflow_call:
 
 permissions:

--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: Setup Node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,11 @@
+name: PR
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    uses: ./.github/workflows/_run-tests.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,3 +9,7 @@ permissions:
 jobs:
   tests:
     uses: ./.github/workflows/_run-tests.yml
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/pay-ci/.github/workflows/_run-dependency-review.yml@master

--- a/.github/workflows/prevent-merge-if-release-open.yml
+++ b/.github/workflows/prevent-merge-if-release-open.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check for unmerged release
         id: check_pr
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         env:
           THIS_PR_NUMBER: ${{ github.event.pull_request.number }}
         with:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -17,9 +17,9 @@ jobs:
     if: "contains(github.event.head_commit.message, '[automated release]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: Setup Node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   unit-tests:
-    uses: ./.github/workflows/run-tests.yml
+    uses: ./.github/workflows/_run-tests.yml
   publish:
     needs: unit-tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
We want to run the [dependency-review shared workflow](https://github.com/alphagov/pay-ci/pull/1329) on pull requests in this repository, to replace the Snyk PR checks.

The main app repositories have a dedicated `pr.yml` workflow file, with a shared `_run-tests.yml` workflow called pre- and post-merge. I've since added this to the [product page repository](https://github.com/alphagov/pay-product-page/pull/777) as well.

In an attempt to get the repository workflows in a consistent state, I've:

- added a new `pr.yml` workflow
- renamed the `run-tests` job to `tests`
- updated the deprecated Github Action versions
- finally, included the `dependency-review` action in the `pr.yml` workflow 